### PR TITLE
Make ClassTrait::$extend default null rather than uninitialized

### DIFF
--- a/src/Delegate/ClassTrait.php
+++ b/src/Delegate/ClassTrait.php
@@ -22,7 +22,7 @@ trait ClassTrait
     /** @var Import[] */
     private array $imports = [];
 
-    private string $extend;
+    private ?string $extend = null;
 
     /** @var string[] */
     private array $implements = [];


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | fix
| BC Break     | No
| Fixed issues | #1 

#### Summary

This makes $extend be by default null.  This appears to be the intended behaviour, as the value is compared to null in hasExtends() - in the current implementation this is impossible.
